### PR TITLE
Update install-guide.md

### DIFF
--- a/installation/install-guide.md
+++ b/installation/install-guide.md
@@ -380,9 +380,9 @@ Edit `/etc/elasticsearch/elasticsearch.yml` and add the following lines:
 network.host: 127.0.0.1
 script.inline: on
 cluster.name: hive
-threadpool.index.queue_size: 100000
-threadpool.search.queue_size: 100000
-threadpool.bulk.queue_size: 1000
+thread_pool.index.queue_size: 100000
+thread_pool.search.queue_size: 100000
+thread_pool.bulk.queue_size: 1000
 ```
 
 Start the service:


### PR DESCRIPTION
When walking through the installation instructions, I edited my `elasticsearch.yml` with the following information

```
network.host: 127.0.0.1
script.inline: on
cluster.name: hive
threadpool.index.queue_size: 100000
threadpool.search.queue_size: 100000
threadpool.bulk.queue_size: 1000
```

as per these [instructions](https://github.com/TheHive-Project/CortexDocs/blob/master/installation/install-guide.md#24-configure-and-start-elasticsearch).

However, when using this ElasticSearch kept failing to start. Further research into this problem revealed that `threadpool` should be `thread_pool`.

These are the correct lines:
```
network.host: 127.0.0.1
script.inline: on
cluster.name: hive
thread_pool.index.queue_size: 100000
thread_pool.search.queue_size: 100000
thread_pool.bulk.queue_size: 1000
```