### PR TITLE
Add documentation about responders MarkAlertAsRead and AddCustomField actions

### DIFF
--- a/api/how-to-create-a-responder.md
+++ b/api/how-to-create-a-responder.md
@@ -299,6 +299,8 @@ If the responder **succeeds** (i.e. it runs without any error):
          a tag to the artifact related to the object
     -    `AddTagToCase` (`{ "type": "AddTagToCase", "tag": "tag to add" }`): add
          a tag to the case related to the object
+    -    `MarkAlertAsRead`: mark the alert related to the object as read
+    -    `AddCustomField` (`{"name": "key", "value": "value", "tpe": "type"`): add a custom field to the case related to the object
    
   The list of acceptable operations will increase in future releases of TheHive.
 


### PR DESCRIPTION
As described in: https://github.com/TheHive-Project/TheHive/releases/tag/3.1.0

The `tpe` parameter could help some more precision, but I couldn't figure out from the current docs what it corresponds to.