### PR TITLE
Adjust AddCustomField to AddCustomFields in docs

### DIFF
--- a/api/how-to-create-a-responder.md
+++ b/api/how-to-create-a-responder.md
@@ -300,7 +300,7 @@ If the responder **succeeds** (i.e. it runs without any error):
     -    `AddTagToCase` (`{ "type": "AddTagToCase", "tag": "tag to add" }`): add
          a tag to the case related to the object
     -    `MarkAlertAsRead`: mark the alert related to the object as read
-    -    `AddCustomField` (`{"name": "key", "value": "value", "tpe": "type"`): add a custom field to the case related to the object
+    -    `AddCustomFields` (`{"name": "key", "value": "value", "tpe": "type"`): add a custom field to the case related to the object
    
   The list of acceptable operations will increase in future releases of TheHive.
 


### PR DESCRIPTION
per commit e7f8b12 to close issue #724, method name is AddCustomFields (note the 's' on the end to make it plural), not AddCustomField.