### PR TITLE
Add more notes on Cortex 3 + Elasticsearch 6.x support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ physical machine with similar specifications.
 ## What's New
 
 - [Quick Start Guide](admin/quick-start.md)
-- [API Guide](api/api-guide.md) (updated for Cortex 2)
+- [API Guide](api/api-guide.md) (updated for Cortex 2 and newer)
 - [Installation Guide](installation/install-guide.md)
 - [How to Configure Analyzers](analyzer_requirements.md)
 - [Training Material](https://github.com/TheHive-Project/TheHiveDocs/blob/master/training-material.md)

--- a/admin/admin-guide.md
+++ b/admin/admin-guide.md
@@ -116,8 +116,8 @@ As described in the section above, Analyzers can only be configured using the We
 
 ### Database
 
-Cortex relies on the Elasticsearch 5.x search engine to store all persistent data.
-Elasticsearch 5.x is not part of the Cortex package. It must be installed and configured
+Cortex relies on the Elasticsearch 5.x (Cortex 3 also supports Elasticsearch 6.x) search engine to store all persistent data.
+Elasticsearch is not part of the Cortex package. It must be installed and configured
 as a standalone instance which can be located on the same machine. For more
 information on how to set up Elasticsearch, please refer to [Elasticsearch
 installation guide](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/_installation.html).

--- a/api/api-guide.md
+++ b/api/api-guide.md
@@ -1,5 +1,5 @@
 # API Guide
-This guide applies only to Cortex 2. It is not applicable to Cortex 1.
+This guide applies only to Cortex 2 and newer. It is not applicable to Cortex 1.
 
 ## Table of Contents
   * [Introduction](#introduction)

--- a/api/how-to-create-an-analyzer.md
+++ b/api/how-to-create-an-analyzer.md
@@ -569,7 +569,7 @@ configuration in `/etc/cortex/application.conf` if needed. You can provide this 
 ### Verify Execution
 Use these three simple checks before submtting your analyzer:
 
--   Ensure it works with the expecyed configuration, TLP or dataType.
+-   Ensure it works with the expected configuration, TLP or dataType.
 -   Ensure it works with missing configuration, dataType or TLP: your
 analyzer must generate an explicit error message.
 -   Ensure the long report template handles error messages correctly.

--- a/installation/install-guide.md
+++ b/installation/install-guide.md
@@ -1,5 +1,5 @@
 # Installation Guide
-This guide applies to Cortex 2 only.
+This guide applies to Cortex 2 and newer only.
 
 Before installing Cortex, you need to choose the installation option which suits your environment as described below, install the analyzers then proceed to the configuration using the [Quick Start Guide](../admin/quick-start.md). For more advanced configuration options, please refer to the [Administration Guide](../admin/admin-guide.md).
 
@@ -83,7 +83,7 @@ echo 'deb https://dl.bintray.com/thehive-project/debian-beta any main' | sudo te
 ### Docker
 To use the Docker image, you must use [Docker](https://www.docker.com/) (courtesy of Captain Obvious).
 
-Cortex 2 requires [Elasticsearch](#elasticsearch-inside-a-docker) to run. You can use `docker-compose` to start them together in Docker or install and configure Elasticsearch manually.
+Cortex 2 and newer requires [Elasticsearch](#elasticsearch-inside-a-docker) to run. You can use `docker-compose` to start them together in Docker or install and configure Elasticsearch manually.
 
 #### Use Docker-compose
 [Docker-compose](https://docs.docker.com/compose/install/) can start multiple dockers and link them together.
@@ -183,7 +183,7 @@ Like analyzers, responders are embedded in the docker image under `/opt/Cortex-A
 Once the Docker image is up and running, proceed to the configuration using the [Quick Start Guide](../admin/quick-start.md). For more advanced configuration options, please refer to the [Administration Guide](../admin/admin-guide.md).
 
 #### Pre-release Versions
-If you would like to use pre-release, beta versions of our Docker images and help us find bugs to the benefit of the whole community, please use `thehiveproject/cortex:version-RCx`. For example `thehiveproject/cortex:2.1.0-RC1`.
+If you would like to use pre-release, beta versions of our Docker images and help us find bugs to the benefit of the whole community, please use `thehiveproject/cortex:version-RCx`. For example `thehiveproject/cortex:3.0.0-RC4`.
 
 ### Binary
 The following section contains the instructions to manually install Cortex using binaries on **Ubuntu 16.04 LTS**. 
@@ -192,7 +192,7 @@ The following section contains the instructions to manually install Cortex using
 Install a minimal Ubuntu 16.04 system with the following software:
 
 - Java runtime environment 1.8+ (JRE)
-- Elasticsearch 5.x
+- Elasticsearch 5.x (Cortex 3 also supports Elasticsearch 6.x)
 
 Make sure your system is up-to-date:
 


### PR DESCRIPTION
Add more notes on Cortex 3 + Elasticsearch 6.x support
(Most notes still pointed at Cortex 2 + Elasticsearch 5.x)