### PR TITLE
reduce analyzer requirements installation time

### DIFF
--- a/installation/install-guide.md
+++ b/installation/install-guide.md
@@ -462,8 +462,10 @@ git clone https://github.com/TheHive-Project/Cortex-Analyzers
 Each analyzer comes with its own, pip compatible `requirements.txt` file. You can install all requirements with the following commands:
 
 ```
-for I in $(find Cortex-Analyzers -name 'requirements.txt'); do sudo -H pip2 install -r $I; done && \
-for I in $(find Cortex-Analyzers -name 'requirements.txt'); do sudo -H pip3 install -r $I || true; done
+for I in $(find Cortex-Analyzers -name 'requirements.txt'); do cat >> combined_requirements.txt < $I; sort -u -o combined_requirements.txt combined_requirements.txt; done
+sudo -H pip2 install -r combined_requirements.txt
+sudo -H pip3 install -r combined_requirements.txt
+rm combined_requirements.txt
 ```
 
 Next, you'll need to tell Cortex where to find the analyzers. Analyzers may be in different directories as shown in this dummy example of the Cortex configuration file (`application.conf`):


### PR DESCRIPTION
While your solution to install all analyzer requirements looks clean and easy to understand, i've always been annoyed a litte about how time consuming it is to watch pip & pip3 going through all requirements.txt, especially because a lot of analyzers share the same 'base' requirements like `cortexutils` or `requests`.

So by deduplicating all requirements and combining them into one single requirements file, you can speed p the hole process. As of today, the linecount of `combined_requirements.txt` is 71, compared to 277 overall requirements count.

```
root@cortex:/opt# for I in $(find Cortex-Analyzers -name 'requirements.txt'); do cat >> combined_requirements.txt < $I; sort -u -o combined_requirements.txt combined_requirements.txt; done'
root@cortex:/opt# for I in $(find Cortex-Analyzers -name 'requirements.txt'); do cat >> all_requirements.txt < $I; sort -o all_requirements.txt all_requirements.txt; done

root@cortex:/opt# wc combined_requirements.txt 
  71   78 1142 all_requirements.txt
root@cortex:/opt# wc all_requirements.txt 
 277  290 3427 combined_requirements.tx
```
It might not be the prettiest solution so feel free to edit, if you're considering to accept this pull request.
